### PR TITLE
Add the possibility to define additional fields to bindings nodes in que...

### DIFF
--- a/src/Amqp/Base/Builder/Amqp.php
+++ b/src/Amqp/Base/Builder/Amqp.php
@@ -167,7 +167,7 @@ class Amqp implements Interfaces\Amqp
 
         $queue = new AMQPQueue($this->channel($configuration['channel']));
 
-        $queue->setName($this->getName($configuration['name']));
+        $queue->setName(isset($configuration['name']) ? $this->getName($configuration['name']) : $queueName);
         $queue->setFlags($this->buildBitmask($configuration['flags']));
         if (isset($configuration['arguments'])) {
             $queue->setArguments($this->getQueueProperties($configuration['arguments']));
@@ -236,9 +236,8 @@ class Amqp implements Interfaces\Amqp
             return $exchange;
         }
 
-        if (isset($configuration['name'])) {
-            $exchange->setName($this->getName($configuration['name']));
-        }
+        $exchange->setName(isset($configuration['name']) ? $this->getName($configuration['name']) : $exchangeName);
+
         if (isset($configuration['flags'])) {
             $exchange->setFlags($this->buildBitmask($configuration['flags']));
         }

--- a/src/Amqp/Base/Config/Amqp.php
+++ b/src/Amqp/Base/Config/Amqp.php
@@ -14,7 +14,6 @@ class Amqp implements ConfigurationInterface, NamedConfigInterface
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('amqp');
-
         $rootNode
             ->ignoreExtraKeys()
             ->children()
@@ -115,6 +114,7 @@ class Amqp implements ConfigurationInterface, NamedConfigInterface
                             ->end()
                             ->arrayNode('bindings')
                                 ->prototype('array')
+                                    ->ignoreExtraKeys()
                                     ->children()
                                         ->scalarNode('exchange')
                                             ->isRequired()
@@ -194,6 +194,7 @@ class Amqp implements ConfigurationInterface, NamedConfigInterface
                             ->end()
                             ->arrayNode('bindings')
                                 ->prototype('array')
+                                    ->ignoreExtraKeys()
                                     ->children()
                                         ->scalarNode('exchange')
                                             ->isRequired()


### PR DESCRIPTION
Add the possibility to define additional fields to bindings nodes in queues and exchanges

Use the default queueName or exchangeName if no name node is defined
