### PR TITLE
Updated libevent php module version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/config": "~2.6",
 
         "ext-amqp": ">=1.0",
-        "ext-libevent": ">=1.0"
+        "ext-libevent": ">=0.1.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/config": "~2.6",
 
         "ext-amqp": ">=1.0",
-        "ext-libevent": ">=2.0"
+        "ext-libevent": ">=1.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Latest version is 0.1.0, according to http://pecl.php.net/package/libevent
